### PR TITLE
Advertise service.

### DIFF
--- a/BLE_MIDI.ino
+++ b/BLE_MIDI.ino
@@ -66,7 +66,9 @@ void setup() {
   pService->start();
 
   // Start advertising
-  pServer->getAdvertising()->start();
+  BLEAdvertising *pAdvertising = pServer->getAdvertising();
+  pAdvertising->addServiceUUID(pService->getUUID());
+  pAdvertising->start();
 }
 
 void loop() {


### PR DESCRIPTION
The BLE MIDI service was not being advertised so iOS apps such as GarageBand and midimittr could not connect.